### PR TITLE
Add support for AndroidX and Cordova 9

### DIFF
--- a/scripts/android/editManifest.js
+++ b/scripts/android/editManifest.js
@@ -1,8 +1,8 @@
 module.exports = function(context) {
-    var fs = context.requireCordovaModule('fs')
-    var path = context.requireCordovaModule('path')
-    var Q = context.requireCordovaModule('q')
-    var xml = context.requireCordovaModule('cordova-common').xmlHelpers
+    var fs = require('fs')
+    var path = require('path')
+    var Q = require('q')
+    var xml = require('cordova-common').xmlHelpers
 
     var deferred = Q.defer()
 

--- a/scripts/android/editManifest.js
+++ b/scripts/android/editManifest.js
@@ -27,7 +27,7 @@ module.exports = function(context) {
     if (filepath != null) {
         doc = xml.parseElementtreeSync(filepath)
         doc.getroot().find('./application').attrib['android:name'] =
-            'android.support.multidex.MultiDexApplication'
+            'androidx.multidex.MultiDexApplication'
         fs.writeFileSync(filepath, doc.write({ indent: 4 }))
         deferred.resolve()
     } else {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,5 +5,5 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:multidex:1.0.1'
+  implementation 'androidx.multidex:multidex:2.0.1'
 }


### PR DESCRIPTION
This PR solves two issues:

* It provides compatibility with Cordova 9 by switching to the newer `require(...)` import statements. Previously, importing would fail with Cordova 9 due to no longer supported imports.
* It updates the plugin to use the newer AndroidX based multidex library `2.0.1`. 